### PR TITLE
Support EL platform

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   license: Apache License, Version 2.0
   min_ansible_version: 1.9.4
   platforms:
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7


### PR DESCRIPTION
Ansible Galaxy ではプラットフォームの指定に`CentOS`はサポートされていないため、`EL`への変更を行いました。