### PR TITLE
fix secret arguments no_log=True should be set.

### DIFF
--- a/library/niftycloud.py
+++ b/library/niftycloud.py
@@ -313,7 +313,7 @@ def main():
 	module = AnsibleModule(
 		argument_spec = dict(
 			access_key          = dict(required=True,  type='str'),
-			secret_access_key   = dict(required=True,  type='str'),
+			secret_access_key   = dict(required=True,  type='str', no_log=True),
 			endpoint            = dict(required=True,  type='str'),
 			instance_id         = dict(required=True,  type='str'),
 			state               = dict(required=True,  type='str'),

--- a/library/niftycloud_lb.py
+++ b/library/niftycloud_lb.py
@@ -194,7 +194,7 @@ def main():
 	module = AnsibleModule(
 		argument_spec = dict(
 			access_key          = dict(required=True,  type='str'),
-			secret_access_key   = dict(required=True,  type='str'),
+			secret_access_key   = dict(required=True,  type='str', no_log=True),
 			endpoint            = dict(required=True,  type='str'),
 			instance_id         = dict(required=True,  type='str'),
 			instance_port       = dict(required=False, type='int', default=None),

--- a/library/niftycloud_volume.py
+++ b/library/niftycloud_volume.py
@@ -187,7 +187,7 @@ def main():
 	module = AnsibleModule(
 		argument_spec = dict(
 			access_key          = dict(required=True,  type='str'),
-			secret_access_key   = dict(required=True,  type='str'),
+			secret_access_key   = dict(required=True,  type='str', no_log=True),
 			endpoint            = dict(required=True,  type='str'),
 			size                = dict(required=True,  type='str'),
 			volume_id           = dict(required=False, type='str', default=None),


### PR DESCRIPTION
http://docs.ansible.com/ansible/dev_guide/developing_modules_checklist.html
>For password / secret arguments no_log=True should be set.

It mask secret arguments with "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER".
like this.

```
TASK [xxxxxx : create instance] ***********************************************
changed: [localhost -> localhost] => {
    "changed": true, 
    "instance_id": "xxxxxx", 
    "invocation": {
        "module_args": {
            "access_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "accounting_type": "2", 
            "availability_zone": "east-14", 
            "endpoint": "east-1.cp.cloud.nifty.com", 
            "image_id": "26", 
            "instance_id": "xxxxxx", 
            "instance_type": "e-mini", 
            "ip_type": "static", 
            "key_name": "xxxxxx", 
            "public_ip": null, 
            "secret_access_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "security_group": "xxxxxx", 
            "startup_script": null, 
            "startup_script_vars": {}, 
            "state": "running"
        }, 
        "module_name": "niftycloud"
    }, 
    "msg": "created", 
    "status": 16
}
```