### PR TITLE
fix niftycloud startup script required

### DIFF
--- a/library/niftycloud.py
+++ b/library/niftycloud.py
@@ -312,7 +312,7 @@ def main():
 			ip_type             = dict(required=False, type='str',  default=None),
 			public_ip           = dict(required=False, type='str',  default=None),
 			startup_script      = dict(required=False, type='str',  default=None),
-			startup_script_vars = dict(required=False, type='dict', deafult={})
+			startup_script_vars = dict(required=False, type='dict', default={})
 		)
 	)
 

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -7,6 +7,7 @@ import unittest
 import mock
 import niftycloud
 import xml.etree.ElementTree as etree
+import copy
 
 class TestNiftycloud(unittest.TestCase):
 	def setUp(self):
@@ -181,6 +182,42 @@ class TestNiftycloud(unittest.TestCase):
 					(True, 16, 'created'),
 					niftycloud.create_instance(self.mockModule)
 				)
+
+        # create success without startup_script
+        def test_create_instance_without_startup_script_success(self):
+		params = copy.deepcopy(self.mockModule.params)
+		params['startup_script'] = None
+		params['startup_script_vars'] = {}
+		
+		mock_module = mock.MagicMock(
+			params=params,
+			fail_json = copy.deepcopy(self.mockModule.fail_json)
+		)
+
+                with mock.patch('requests.post', self.mockRequestsPostRunInstance):
+                        with mock.patch('niftycloud.get_instance_state', self.mockGetInstanceState16):
+                                self.assertEqual(
+                                        (True, 16, 'created'),
+                                        niftycloud.create_instance(mock_module)
+                                )
+
+        # create success without startup_script_vars
+        def test_create_instance_without_startup_script_vars_success(self):
+                params = copy.deepcopy(self.mockModule.params)
+		params['startup_script'] = '{0}/files/startup_script_blank'.format(os.path.dirname(__file__))
+                params['startup_script_vars'] = {}
+
+                mock_module = mock.MagicMock(
+                        params=params,
+                        fail_json = copy.deepcopy(self.mockModule.fail_json)
+                )
+
+                with mock.patch('requests.post', self.mockRequestsPostRunInstance):
+                        with mock.patch('niftycloud.get_instance_state', self.mockGetInstanceState16):
+                                self.assertEqual(
+                                        (True, 16, 'created'),
+                                        niftycloud.create_instance(mock_module)
+                                )
 
 	# change state failed
 	def test_create_instance_failed(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME

niftycloud

##### SUMMARY

If startup_script_path or startup_script_vars are undefined, niftycloud module are failure.



##### Bug Case 1: undefined startup_script_path

```
  local_action:
    module: niftycloud
    access_key: "XXXXXXXXXXXXXXXXXXX"
    secret_access_key: "XXXXXXXXXXXXXXXXXXX"
    endpoint: "east-1.cp.cloud.nifty.com"
    instance_id: "xxxxx"
    state: "running"
    image_id: "26"
    key_name: "xxxxx"
    security_group: "xxxxx"
    instance_type: "e-mini"
    availability_zone: "east-14"
    accounting_type: "2"
    ip_type: "static"
```

```
TASK [xxxxx : create instance] ***********************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: coercing to Unicode: need string or buffer, NoneType found
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_q5K1YY/ansible_module_niftycloud.py\", line 343, in <module>\n    main()\n  File \"/tmp/ansible_q5K1YY/ansible_module_niftycloud.py\", line 328, in main\n    (changed, current_state, msg) = start_instance(module, current_state)\n  File \"/tmp/ansible_q5K1YY/ansible_module_niftycloud.py\", line 215, in start_instance\n    return create_instance(module)\n  File \"/tmp/ansible_q5K1YY/ansible_module_niftycloud.py\", line 181, in create_instance\n    with open(startup_script_path, 'r') as fp:\nTypeError: coercing to Unicode: need string or buffer, NoneType found\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

##### Bug Case 2: undefined startup_script_vars

```
-------
  local_action:
    module: niftycloud
    access_key: "XXXXXXXXXXXXXXXXXXX"
    secret_access_key: "XXXXXXXXXXXXXXXXXXX"
    endpoint: "east-1.cp.cloud.nifty.com"
    instance_id: "xxxxx"
    state: "running"
    image_id: "26"
    key_name: "xxxxx"
    security_group: "xxxxx"
    instance_type: "e-mini"
    availability_zone: "east-14"
    accounting_type: "2"
    ip_type: "static"
    startup_script: "/root/none.sh"
-------
```

```
TASK [xxxxx : create instance] ***********************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: format() argument after ** must be a mapping, not NoneType
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Ce0R_b/ansible_module_niftycloud.py\", line 343, in <module>\n    main()\n  File \"/tmp/ansible_Ce0R_b/ansible_module_niftycloud.py\", line 328, in main\n    (changed, current_state, msg) = start_instance(module, current_state)\n  File \"/tmp/ansible_Ce0R_b/ansible_module_niftycloud.py\", line 215, in start_instance\n    return create_instance(module)\n  File \"/tmp/ansible_Ce0R_b/ansible_module_niftycloud.py\", line 183, in create_instance\n    startup_script = startup_script_template.format(**startup_script_vars)\nTypeError: format() argument after ** must be a mapping, not NoneType\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

##### Test results

```
# nosetests --no-byte-compile --with-coverage > /dev/null 2>&1 && coverage report --include=./niftycloud*.py
Name                   Stmts   Miss  Cover
------------------------------------------
niftycloud.py            160     20    88%
niftycloud_lb.py         118     21    82%
niftycloud_volume.py     100     24    76%
------------------------------------------
TOTAL                    378     65    83%
```
