### PR TITLE
Fix/print api error response

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -26,9 +26,9 @@
 ```
 Name                   Stmts   Miss  Cover
 ------------------------------------------
-niftycloud.py            175     16    91%
-niftycloud_lb.py         121     10    92%
-niftycloud_volume.py     103     14    86%
+niftycloud.py            178     20    89%
+niftycloud_lb.py         125     14    89%
+niftycloud_volume.py     105     16    85%
 ------------------------------------------
-TOTAL                    399     40    90%
+TOTAL                    408     50    88%
 ```

--- a/library/README.md
+++ b/library/README.md
@@ -26,9 +26,9 @@
 ```
 Name                   Stmts   Miss  Cover
 ------------------------------------------
-niftycloud.py            172     15    91%
-niftycloud_lb.py         118      7    94%
-niftycloud_volume.py     100     13    87%
+niftycloud.py            175     16    91%
+niftycloud_lb.py         121     10    92%
+niftycloud_volume.py     103     14    86%
 ------------------------------------------
-TOTAL                    390     35    91%
+TOTAL                    399     40    90%
 ```

--- a/library/README.md
+++ b/library/README.md
@@ -22,13 +22,13 @@
 # cat *,cover
 ```
 
-* results (2016/8/22)
+* results (2017/03/06)
 ```
 Name                   Stmts   Miss  Cover
 ------------------------------------------
-niftycloud.py            165     31    81%
-niftycloud_lb.py         116     21    82%
-niftycloud_volume.py     100     23    77%
+niftycloud.py            172     15    91%
+niftycloud_lb.py         118      7    94%
+niftycloud_volume.py     100     13    87%
 ------------------------------------------
-TOTAL                    381     75    80%
+TOTAL                    390     35    91%
 ```

--- a/library/niftycloud.py
+++ b/library/niftycloud.py
@@ -137,6 +137,13 @@ def request_to_api(module, method, action, params):
 	else:
 		module.fail_json(status=-1, msg='changes failed (http request failed)')
 
+def get_api_error(xml_body):
+	info = dict(
+		code    = xml_body.find('.//Errors/Error/Code').text,
+		message = xml_body.find('.//Errors/Error/Message').text
+	)
+	return info
+
 def get_instance_state(module):
 	params = dict()
 	params['InstanceId.1'] = module.params['instance_id']

--- a/library/niftycloud.py
+++ b/library/niftycloud.py
@@ -225,7 +225,14 @@ def create_instance(module):
 		else:
 			module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (create_instance)')
 	else:
-		module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (create_instance)')
+		error_info = get_api_error(res['xml_body'])
+		module.fail_json(
+			status=-1,
+			instance_id=module.params['instance_id'],
+			msg='changes failed (create_instance)',
+			error_code=error_info.get('code'),
+			error_message=error_info.get('message')
+		)
 
 def start_instance(module, current_state):
 	goal_state = 16
@@ -275,7 +282,14 @@ def start_instance(module, current_state):
 			else:
 				module.fail_json(status=current_state, instance_id=module.params['instance_id'], msg='changes failed (start_instance)')
 		else:
-			module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (start_instance)')
+			error_info = get_api_error(res['xml_body'])
+			module.fail_json(
+				status=-1,
+				instance_id=module.params['instance_id'],
+				msg='changes failed (start_instance)',
+				error_code=error_info.get('code'),
+				error_message=error_info.get('message')
+			)
 
 def stop_instance(module, current_state):
 	goal_state = 80
@@ -303,7 +317,14 @@ def stop_instance(module, current_state):
 		else:
 			module.fail_json(status=current_state, instance_id=module.params['instance_id'], msg='changes failed (stop_instance)')
 	else:
-		module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (stop_instance)')
+		error_info = get_api_error(res['xml_body'])
+		module.fail_json(
+			status=-1,
+			instance_id=module.params['instance_id'],
+			msg='changes failed (stop_instance)',
+			error_code=error_info.get('code'),
+			error_message=error_info.get('message')
+		)
 
 def restart_instance(module, current_state):
 	changed = False

--- a/library/niftycloud_lb.py
+++ b/library/niftycloud_lb.py
@@ -118,7 +118,13 @@ def get_state_instance_in_load_balancer(module):
 				return 'present'
 		return 'absent'
 	else:
-		module.fail_json(status=-1, msg='check current state failed')
+		error_info = get_api_error(res['xml_body'])
+		module.fail_json(
+			status=-1,
+			msg='check current state failed',
+			error_code=error_info.get('code'),
+			error_message=error_info.get('message')
+		)
 
 def is_present_in_load_balancer(module):
 	return True if get_state_instance_in_load_balancer(module) == 'present' else False
@@ -151,7 +157,13 @@ def regist_instance(module):
 		current_status = get_state_instance_in_load_balancer(module)
 		return (True, current_status)
 	else:
-		module.fail_json(status=-1, msg='changes failed (regist_instance)')
+		error_info = get_api_error(res['xml_body'])
+		module.fail_json(
+			status=-1,
+			msg='changes failed (regist_instance)',
+			error_code=error_info.get('code'),
+			error_message=error_info.get('message')
+		)
 
 def deregist_instance(module):
 	params = dict()
@@ -192,10 +204,22 @@ def deregist_instance(module):
 				deregister_lbs.append(lb_label)
 				changed = True
 			else:
-				module.fail_json(status=-1, msg='changes failed (deregist_instance)')
+				error_info = get_api_error(res['xml_body'])
+				module.fail_json(
+					status=-1,
+					msg='changes failed (deregist_instance)',
+					error_code=error_info.get('code'),
+					error_message=error_info.get('message')
+				)
 		return (changed, 'absent(' + ','.join(deregister_lbs) + ')')
 	else:
-		module.fail_json(status=-1, msg='get load balancers information failed')
+		error_info = get_api_error(lbs_res['xml_body'])
+		module.fail_json(
+			status=-1,
+			msg='get load balancers information failed',
+			error_code=error_info.get('code'),
+			error_message=error_info.get('message')
+		)
 
 def main():
 	module = AnsibleModule(

--- a/library/niftycloud_lb.py
+++ b/library/niftycloud_lb.py
@@ -95,6 +95,13 @@ def request_to_api(module, method, action, params):
 	else:
 		module.fail_json(status=-1, msg='changes failed (http request failed)')
 
+def get_api_error(xml_body):
+	info = dict(
+		code    = xml_body.find('.//Errors/Error/Code').text,
+		message = xml_body.find('.//Errors/Error/Message').text
+	)
+	return info
+
 def describe_load_balancers(module, params):
 	return request_to_api(module, 'GET', 'DescribeLoadBalancers', params)
 

--- a/library/niftycloud_volume.py
+++ b/library/niftycloud_volume.py
@@ -99,6 +99,13 @@ def request_to_api(module, method, action, params):
 	else:
 		module.fail_json(status=-1, msg='changes failed (http request failed)')
 
+def get_api_error(xml_body):
+	info = dict(
+		code    = xml_body.find('.//Errors/Error/Code').text,
+		message = xml_body.find('.//Errors/Error/Message').text
+	)
+	return info
+
 def get_volume_state(module):
 	params = dict()
 

--- a/library/niftycloud_volume.py
+++ b/library/niftycloud_volume.py
@@ -156,7 +156,14 @@ def create_volume(module):
 		else:
 			module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (create_volume)')
 	else:
-		module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (create_volume)')
+		error_info = get_api_error(res['xml_body'])
+		module.fail_json(
+			status=-1,
+			instance_id=module.params['instance_id'],
+			msg='changes failed (create_volume)',
+			error_code=error_info.get('code'),
+			error_message=error_info.get('message')
+		)
 
 def attach_volume(module):
 	(current_state, instance_id) = get_volume_state(module)
@@ -181,7 +188,14 @@ def attach_volume(module):
 			else:
 				module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (attach_volume)')
 		else:
-			module.fail_json(status=-1, instance_id=module.params['instance_id'], msg='changes failed (attach_volume)')
+			error_info = get_api_error(res['xml_body'])
+			module.fail_json(
+				status=-1,
+				instance_id=module.params['instance_id'],
+				msg='changes failed (attach_volume)',
+				error_code=error_info.get('code'),
+				error_message=error_info.get('message')
+			)
 	elif current_state == 'attached' and instance_id == module.params['instance_id']:
 		return (False, current_state)
 	else:

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -181,6 +181,23 @@ class TestNiftycloud(unittest.TestCase):
 				(self.mockModule, method, action, params)
 			)
 
+	# get api error code & message
+	def test_get_api_error(self):
+		method = 'GET'
+		action = 'DescribeInstances'
+		params = dict(
+			ImageId = self.mockModule.params['image_id'],
+			KeyName = self.mockModule.params['key_name'],
+			InstanceId = self.mockModule.params['instance_id']
+		)
+
+		with mock.patch('requests.get', self.mockRequestsInternalServerError):
+			info = niftycloud.request_to_api(self.mockModule, method, action, params)
+
+		error_info = niftycloud.get_api_error(info['xml_body'])
+		self.assertEqual(error_info['code'],    'Server.InternalError')
+		self.assertEqual(error_info['message'], 'An error has occurred. Please try again later.')
+
 	# running
 	def test_get_instance_state_present(self):
 		with mock.patch('requests.get', self.mockRequestsGetDescribeInstance):

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -131,6 +131,23 @@ class TestNiftycloud(unittest.TestCase):
 		self.assertEqual(etree.tostring(info['xml_body']),
 				 etree.tostring(etree.fromstring(self.xml['runInstance'])))
 
+	# api error
+	def test_request_to_api_error(self):
+		method = 'GET'
+		action = 'DescribeInstances'
+		params = dict(
+			ImageId = self.mockModule.params['image_id'],
+			KeyName = self.mockModule.params['key_name'],
+			InstanceId = self.mockModule.params['instance_id']
+		)
+
+		with mock.patch('requests.get', self.mockRequestsInternalServerError):
+			info = niftycloud.request_to_api(self.mockModule, method, action, params)
+
+		self.assertEqual(info['status'], 500)
+		self.assertEqual(etree.tostring(info['xml_body']),
+				 etree.tostring(etree.fromstring(self.xml['internalServerError'])))
+
 	# method failed
 	def test_request_to_api_unknown(self):
 		method = 'UNKNOWN'
@@ -148,7 +165,7 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 	# network error
-	def test_request_to_api_error(self):
+	def test_request_to_api_request_error(self):
 		method = 'GET'
 		action = 'DescribeInstances'
 		params = dict(

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -62,7 +62,7 @@ class TestNiftycloud(unittest.TestCase):
 		self.mockRequestsInternalServerError = mock.MagicMock(
 			return_value=mock.MagicMock(
 				status_code = 500,
-				text = self.xml['describeInstance']
+				text = self.xml['internalServerError']
 			))
 
 		self.mockGetInstanceStateError = mock.MagicMock(return_value=-1)
@@ -573,6 +573,17 @@ niftycloud_api_response_sample = dict(
     </item>
   </instancesSet>
 </StopInstancesResponse>
+''',
+	internalServerError = '''
+<Response>
+ <Errors>
+  <Error>
+   <Code>Server.InternalError</Code>
+   <Message>An error has occurred. Please try again later.</Message>
+  </Error>
+ </Errors>
+ <RequestID>5ec8da0a-6e23-4343-b474-ca0bb5c22a51</RequestID>
+</Response>
 '''
 )
 

--- a/library/tests/test_niftycloud_lb.py
+++ b/library/tests/test_niftycloud_lb.py
@@ -133,6 +133,19 @@ class TestNiftycloud(unittest.TestCase):
 				(self.mockModule, method, action, params)
 			)
 
+	# get api error code & message
+	def test_get_api_error(self):
+		method = 'GET'
+		action = 'DescribeLoadBalancers'
+		params = dict()
+
+		with mock.patch('requests.get', self.mockRequestsInternalServerError):
+			info = niftycloud_lb.request_to_api(self.mockModule, method, action, params)
+
+		error_info = niftycloud_lb.get_api_error(info['xml_body'])
+		self.assertEqual(error_info['code'],    'Server.InternalError')
+		self.assertEqual(error_info['message'], 'An error has occurred. Please try again later.')
+
 	# describe
 	def test_describe_load_balancers(self):
 		with mock.patch('requests.get', self.mockRequestsGetDescribeLoadBalancers):

--- a/library/tests/test_niftycloud_lb.py
+++ b/library/tests/test_niftycloud_lb.py
@@ -95,6 +95,19 @@ class TestNiftycloud(unittest.TestCase):
 		self.assertEqual(etree.tostring(info['xml_body']),
 				 etree.tostring(etree.fromstring(self.xml['describeLoadBalancers'])))
 
+	# api error
+	def test_request_to_api_error(self):
+		method = 'GET'
+		action = 'DescribeLoadBalancers'
+		params = dict()
+
+		with mock.patch('requests.get', self.mockRequestsInternalServerError):
+			info = niftycloud_lb.request_to_api(self.mockModule, method, action, params)
+
+		self.assertEqual(info['status'], 500)
+		self.assertEqual(etree.tostring(info['xml_body']),
+				 etree.tostring(etree.fromstring(self.xml['internalServerError'])))
+
 	# method failed
 	def test_request_to_api_unknown(self):
 		method = 'UNKNOWN'
@@ -108,7 +121,7 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 	# network error
-	def test_request_to_api_error(self):
+	def test_request_to_api_request_error(self):
 		method = 'GET'
 		action = 'DescribeLoadBalancers'
 		params = dict()

--- a/library/tests/test_niftycloud_lb.py
+++ b/library/tests/test_niftycloud_lb.py
@@ -55,7 +55,7 @@ class TestNiftycloud(unittest.TestCase):
 		self.mockRequestsInternalServerError = mock.MagicMock(
 			return_value=mock.MagicMock(
 				status_code = 500,
-				text = self.xml['describeLoadBalancers']
+				text = self.xml['internalServerError']
 			))
 
 		self.mockRequestsError = mock.MagicMock(return_value=None)
@@ -463,6 +463,17 @@ niftycloud_api_response_sample = dict(
     <RequestId>f6dd8353-eb6b-6b4fd32e4f05</RequestId>
   </ResponseMetadata>
 </DeregisterInstancesFromLoadBalancerResponse>
+''',
+	internalServerError = '''
+<Response>
+ <Errors>
+  <Error>
+   <Code>Server.InternalError</Code>
+   <Message>An error has occurred. Please try again later.</Message>
+  </Error>
+ </Errors>
+ <RequestID>5ec8da0a-6e23-4343-b474-ca0bb5c22a51</RequestID>
+</Response>
 '''
 )
 

--- a/library/tests/test_niftycloud_volume.py
+++ b/library/tests/test_niftycloud_volume.py
@@ -91,6 +91,21 @@ class TestNiftycloud(unittest.TestCase):
 		self.assertEqual(etree.tostring(info['xml_body']),
 				 etree.tostring(etree.fromstring(self.xml['describeVolumes'])))
 
+	# api error
+	def test_request_to_api_error(self):
+		method = 'GET'
+		action = 'DescribeVolumes'
+		params = dict(
+			InstanceId = self.mockModule.params['instance_id']
+		)
+
+		with mock.patch('requests.get', self.mockRequestsInternalServerError):
+			info = niftycloud_volume.request_to_api(self.mockModule, method, action, params)
+
+		self.assertEqual(info['status'], 500)
+		self.assertEqual(etree.tostring(info['xml_body']),
+				 etree.tostring(etree.fromstring(self.xml['internalServerError'])))
+
 	# method failed
 	def test_request_to_api_unknown(self):
 		method = 'UNKNOWN'
@@ -106,7 +121,7 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 	# network error
-	def test_request_to_api_error(self):
+	def test_request_to_api_request_error(self):
 		method = 'GET'
 		action = 'DescribeVolumes'
 		params = dict(

--- a/library/tests/test_niftycloud_volume.py
+++ b/library/tests/test_niftycloud_volume.py
@@ -49,7 +49,7 @@ class TestNiftycloud(unittest.TestCase):
 		self.mockRequestsInternalServerError = mock.MagicMock(
 			return_value=mock.MagicMock(
 				status_code = 500,
-				text = self.xml['describeVolumes']
+				text = self.xml['internalServerError']
 			))
 
 		self.mockRequestsError = mock.MagicMock(return_value=None)
@@ -282,6 +282,17 @@ niftycloud_api_response_sample = dict(
   <status>attached</status>
   <attachTime>2010-05-17T11:22:33.456Z</attachTime>
 </AttachVolumeResponse>
+''',
+	internalServerError = '''
+<Response>
+ <Errors>
+  <Error>
+   <Code>Server.InternalError</Code>
+   <Message>An error has occurred. Please try again later.</Message>
+  </Error>
+ </Errors>
+ <RequestID>5ec8da0a-6e23-4343-b474-ca0bb5c22a51</RequestID>
+</Response>
 '''
 )
 

--- a/library/tests/test_niftycloud_volume.py
+++ b/library/tests/test_niftycloud_volume.py
@@ -135,6 +135,21 @@ class TestNiftycloud(unittest.TestCase):
 				(self.mockModule, method, action, params)
 			)
 
+	# get api error code & message
+	def test_get_api_error(self):
+		method = 'GET'
+		action = 'DescribeVolumes'
+		params = dict(
+			InstanceId = self.mockModule.params['instance_id']
+		)
+
+		with mock.patch('requests.get', self.mockRequestsInternalServerError):
+			info = niftycloud_volume.request_to_api(self.mockModule, method, action, params)
+
+		error_info = niftycloud_volume.get_api_error(info['xml_body'])
+		self.assertEqual(error_info['code'],    'Server.InternalError')
+		self.assertEqual(error_info['message'], 'An error has occurred. Please try again later.')
+
 	# get volume state present
 	def test_get_volume_state_present(self):
 		with mock.patch('requests.get', self.mockRequestsGetDescribeVolumes):


### PR DESCRIPTION
output error code and error message in log when error is thrown in API request.

```
TASK [niftycloud/run-instances : Run Instances] ********************************
fatal: [e1devops002 -> localhost]: FAILED! => {"changed": false, "error_code": "Client.InvalidParameterNotFound.NetworkName", "error_message": "The NetworkName 'Private2' does not exist.", "failed": true, "instance_id": "e1devops002", "msg": "changes failed (create_instance)", "status": -1}
````

and i updated coverage result.