### PR TITLE
Setup automating role imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install dependences
-  - pip install ansible nose mock requests
+  - pip install ansible nose coveralls mock requests
 
   # Check ansible version
   - ansible --version
@@ -27,3 +27,4 @@ script:
   
   # NIFTY Cloud modules check
   - nosetests --no-byte-compile --with-coverage --cover-package=library/ --where=library/
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ script:
   # NIFTY Cloud modules check
   - nosetests --no-byte-compile --with-coverage --cover-package=library/ --where=library/
   - coveralls
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install dependences
+  - pip install ansible nose mock requests
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  
+  # NIFTY Cloud modules check
+  - nosetests --no-byte-compile --with-coverage --cover-package=library/ --where=library/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ niftycloud
 
 Ansible role for importing module of NIFTYCloud
 
+[![Build Status](https://travis-ci.org/NIFTYCloud/ansible-role-niftycloud.svg?branch=master)](https://travis-ci.org/NIFTYCloud/ansible-role-niftycloud)
+
 Requirements
 ------------
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ niftycloud
 Ansible role for importing module of NIFTYCloud
 
 [![Build Status](https://travis-ci.org/NIFTYCloud/ansible-role-niftycloud.svg?branch=master)](https://travis-ci.org/NIFTYCloud/ansible-role-niftycloud)
+[![Coverage Status](https://coveralls.io/repos/github/NIFTYCloud/ansible-role-niftycloud/badge.svg?branch=master)](https://coveralls.io/github/NIFTYCloud/ansible-role-niftycloud?branch=master)
 
 Requirements
 ------------


### PR DESCRIPTION
- Enable [Travis CI](https://travis-ci.org/NIFTYCloud/ansible-role-niftycloud) build and test
- Using [Coveralls](https://coveralls.io/github/NIFTYCloud/ansible-role-niftycloud)
- Role is auto-import to [Ansible Galaxy](https://galaxy.ansible.com/NIFTYCloud/niftycloud/) when Travis CI complete