### PR TITLE
fix to encode slash included in parameters by urllib.quote(string, safe)

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -23,27 +23,6 @@
 # cat *,cover
 ```
 
-### About the signature constant value in the test
-
-It is a signature calculated by different methods.
-
-* calculate signature by shell-script
-```
-# METHOD="GET"
-# ENDPOINT="west-1.cp.cloud.nifty.com"
-# API_PATH="/api/"
-# ACCESS_KEY_ID="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-# SECRET_ACCESS_KEY="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-# PARAMS=("Action=DescribeInstances" "AccessKeyId=$ACCESS_KEY_ID" "SignatureMethod=HmacSHA256" "SignatureVersion=2" "InstanceId=test001" "Description=$(echo '/' | nkf -WwMQ | tr = %)")
-
-# SIGNATURE=$(. ./tests/files/calculate_signature_sample.sh; calculate_signature "$METHOD" "$ENDPOINT" "$API_PATH" "$SECRET_ACCESS_KEY" "${PARAMS[@]}")
-# echo $SIGNATURE
-dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=
-
-# QUERY=$(echo "${PARAMS[@]}" "Signature=$(echo $SIGNATURE | nkf -WwMQ | tr = %)" | tr ' ' '&')
-# curl -X GET "https://${ENDPOINT}${API_PATH}?${QUERY}"
-```
-
 * results (2017/03/28)
 ```
 Name                   Stmts   Miss  Cover

--- a/library/README.md
+++ b/library/README.md
@@ -23,6 +23,27 @@
 # cat *,cover
 ```
 
+### About the signature constant value in the test
+
+It is a signature calculated by different methods.
+
+* calculate signature by shell-script
+```
+# METHOD="GET"
+# ENDPOINT="west-1.cp.cloud.nifty.com"
+# API_PATH="/api/"
+# ACCESS_KEY_ID="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+# SECRET_ACCESS_KEY="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+# PARAMS=("Action=DescribeInstances" "AccessKeyId=$ACCESS_KEY_ID" "SignatureMethod=HmacSHA256" "SignatureVersion=2" "InstanceId=test001" "Description=$(echo '/' | nkf -WwMQ | tr = %)")
+
+# SIGNATURE=$(. ./tests/files/calculate_signature_sample.sh; calculate_signature "$METHOD" "$ENDPOINT" "$API_PATH" "$SECRET_ACCESS_KEY" "${PARAMS[@]}")
+# echo $SIGNATURE
+dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=
+
+# QUERY=$(echo "${PARAMS[@]}" "Signature=$(echo $SIGNATURE | nkf -WwMQ | tr = %)" | tr ' ' '&')
+# curl -X GET "https://${ENDPOINT}${API_PATH}?${QUERY}"
+```
+
 * results (2017/03/28)
 ```
 Name                   Stmts   Miss  Cover

--- a/library/niftycloud.py
+++ b/library/niftycloud.py
@@ -95,7 +95,7 @@ EXAMPLES = '''
 def calculate_signature(secret_access_key, method, endpoint, path, params):
 	payload = ""
 	for v in sorted(params.items()):
-		payload += '&{0}={1}'.format(v[0], urllib.quote(str(v[1])))
+		payload += '&{0}={1}'.format(v[0], urllib.quote(str(v[1]), ''))
 	payload = payload[1:]
 
 	string_to_sign = [method, endpoint, path, payload]

--- a/library/niftycloud_lb.py
+++ b/library/niftycloud_lb.py
@@ -53,7 +53,7 @@ EXAMPLES = '''
 def calculate_signature(secret_access_key, method, endpoint, path, params):
 	payload = ""
 	for v in sorted(params.items()):
-		payload += '&{0}={1}'.format(v[0], urllib.quote(str(v[1])))
+		payload += '&{0}={1}'.format(v[0], urllib.quote(str(v[1]), ''))
 	payload = payload[1:]
 
 	string_to_sign = [method, endpoint, path, payload]

--- a/library/niftycloud_volume.py
+++ b/library/niftycloud_volume.py
@@ -57,7 +57,7 @@ EXAMPLES = '''
 def calculate_signature(secret_access_key, method, endpoint, path, params):
 	payload = ""
 	for v in sorted(params.items()):
-		payload += '&{0}={1}'.format(v[0], urllib.quote(str(v[1])))
+		payload += '&{0}={1}'.format(v[0], urllib.quote(str(v[1]), ''))
 	payload = payload[1:]
 
 	string_to_sign = [method, endpoint, path, payload]

--- a/library/tests/files/calculate_signature_sample.sh
+++ b/library/tests/files/calculate_signature_sample.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+function calculate_signature () {
+  METHOD="$1" ; shift
+  ENDPOINT="$1" ; shift
+  API_PATH="$1" ; shift
+  SECRET_ACCESS_KEY="$1" ; shift
+  PARAMS=("$@")
+  
+  SORTED_PARAMS=($(IFS=$'\n'; echo "${PARAMS[*]}" | /bin/sort))
+  PAYLOAD="$(IFS=$'&'; echo "${SORTED_PARAMS[*]}")"
+  SIGNATURE=$(echo -ne "$METHOD\n$ENDPOINT\n$API_PATH\n$PAYLOAD" | openssl dgst -sha256 -binary -hmac "$SECRET_ACCESS_KEY" | base64)
+  
+  echo "$SIGNATURE"
+}

--- a/library/tests/files/calculate_signature_sample.sh
+++ b/library/tests/files/calculate_signature_sample.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+#
+# ### How to Use ###
+#
+# $ METHOD="GET"
+# $ ENDPOINT="west-1.cp.cloud.nifty.com"
+# $ API_PATH="/api/"
+# $ ACCESS_KEY_ID="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+# $ SECRET_ACCESS_KEY="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+# $ PARAMS=("Action=DescribeInstances" "AccessKeyId=$ACCESS_KEY_ID" "SignatureMethod=HmacSHA256" "SignatureVersion=2" "InstanceId=test001" "Description=$(echo '/' | nkf -WwMQ | tr = %)")
+#
+# $ SIGNATURE=$(. ./tests/files/calculate_signature_sample.sh; calculate_signature "$METHOD" "$ENDPOINT" "$API_PATH" "$SECRET_ACCESS_KEY" "${PARAMS[@]}")
+# $ echo $SIGNATURE
+# dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=
+#
+# $ QUERY=$(echo "${PARAMS[@]}" "Signature=$(echo $SIGNATURE | nkf -WwMQ | tr = %)" | tr ' ' '&')
+# $ curl -X GET "https://${ENDPOINT}${API_PATH}?${QUERY}"
+#
+
 function calculate_signature () {
   METHOD="$1" ; shift
   ENDPOINT="$1" ; shift

--- a/library/tests/files/calculate_signature_sample.sh
+++ b/library/tests/files/calculate_signature_sample.sh
@@ -25,7 +25,7 @@ function calculate_signature () {
   SECRET_ACCESS_KEY="$1" ; shift
   PARAMS=("$@")
   
-  SORTED_PARAMS=($(IFS=$'\n'; echo "${PARAMS[*]}" | /bin/sort))
+  SORTED_PARAMS=($(IFS=$'\n'; echo "${PARAMS[*]}" | sort))
   PAYLOAD="$(IFS=$'&'; echo "${SORTED_PARAMS[*]}")"
   SIGNATURE=$(echo -ne "$METHOD\n$ENDPOINT\n$API_PATH\n$PAYLOAD" | openssl dgst -sha256 -binary -hmac "$SECRET_ACCESS_KEY" | base64)
   

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -112,56 +112,8 @@ class TestNiftycloud(unittest.TestCase):
 			Description = '/'
 		)
 
-		# calculate a signature with slash URL-encoded
-		calculate_signature_with_slash_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
-			base64.b64encode(
-				hmac.new(
-					_secret_access_key,
-					'\n'.join([
-						_method,
-						_endpoint,
-						_path,
-						'&'.join([
-							'='.join([
-								_v[0],
-								urllib.quote(str(_v[1]), '')
-							]) for _v in sorted(_params.items())
-						])
-					]),
-					hashlib.sha256
-				).digest()
-			)
-		)
-
-		# calculate a signature with slash don't URL-encoded
-		calculate_signature_with_slash_dont_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
-			base64.b64encode(
-				hmac.new(
-					_secret_access_key,
-					'\n'.join([
-						_method,
-						_endpoint,
-						_path,
-						'&'.join([
-							'='.join([
-								_v[0],
-								urllib.quote(str(_v[1])) # '/' is default value of the 2nd argument
-							]) for _v in sorted(_params.items())
-						])
-					]),
-					hashlib.sha256
-				).digest()
-			)
-		)
-
-		signature                         = niftycloud.calculate_signature(secret_access_key, method, endpoint, path, params)
-		signature_with_slash_encoded      = calculate_signature_with_slash_encoded(secret_access_key, method, endpoint, path, params)
-		signature_with_slash_dont_encoded = calculate_signature_with_slash_dont_encoded(secret_access_key, method, endpoint, path, params)
-
-		# signature == signature_with_slash_encoded != signature_with_slash_dont_encoded
+		signature = niftycloud.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
-		self.assertEqual(signature, signature_with_slash_encoded)
-		self.assertNotEqual(signature, signature_with_slash_dont_encoded)
 
 	# method get
 	def test_request_to_api_get(self):

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -8,6 +8,7 @@ import mock
 import niftycloud
 import xml.etree.ElementTree as etree
 import copy
+import urllib, hmac, hashlib, base64
 
 class TestNiftycloud(unittest.TestCase):
 	def setUp(self):
@@ -78,7 +79,7 @@ class TestNiftycloud(unittest.TestCase):
 		patcher = mock.patch('time.sleep')
 		self.addCleanup(patcher.stop)
 		self.mock_time_sleep = patcher.start()
-			
+
 	# calculate signature
 	def test_calculate_signature(self):
 		secret_access_key = self.mockModule.params['secret_access_key']
@@ -95,6 +96,72 @@ class TestNiftycloud(unittest.TestCase):
 
 		signature = niftycloud.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, 'Y7/0nc3dCK9UNkp+w5sh08ybJLQjh69mXOgcxJijDEU=')
+
+	# calculate signature with string parameter including slash
+	def test_calculate_signature_with_slash(self):
+		secret_access_key = self.mockModule.params['secret_access_key']
+		method = 'GET'
+		endpoint = self.mockModule.params['endpoint']
+		path = '/api/'
+		params = dict(
+			Action = 'DescribeInstances',
+			AccessKeyId = self.mockModule.params['access_key'],
+			SignatureMethod = 'HmacSHA256',
+			SignatureVersion = '2',
+			InstanceId = self.mockModule.params['instance_id'],
+			Description = '/'
+		)
+
+		# calculate a signature with slash URL-encoded
+		calculate_signature_with_slash_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
+			base64.b64encode(
+				hmac.new(
+					_secret_access_key,
+					'\n'.join([
+						_method,
+						_endpoint,
+						_path,
+						'&'.join([
+							'='.join([
+								_v[0],
+								urllib.quote(str(_v[1]), '')
+							]) for _v in sorted(_params.items())
+						])
+					]),
+					hashlib.sha256
+				).digest()
+			)
+		)
+
+		# calculate a signature with slash don't URL-encoded
+		calculate_signature_with_slash_dont_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
+			base64.b64encode(
+				hmac.new(
+					_secret_access_key,
+					'\n'.join([
+						_method,
+						_endpoint,
+						_path,
+						'&'.join([
+							'='.join([
+								_v[0],
+								urllib.quote(str(_v[1])) # '/' is default value of the 2nd argument
+							]) for _v in sorted(_params.items())
+						])
+					]),
+					hashlib.sha256
+				).digest()
+			)
+		)
+
+		signature                         = niftycloud.calculate_signature(secret_access_key, method, endpoint, path, params)
+		signature_with_slash_encoded      = calculate_signature_with_slash_encoded(secret_access_key, method, endpoint, path, params)
+		signature_with_slash_dont_encoded = calculate_signature_with_slash_dont_encoded(secret_access_key, method, endpoint, path, params)
+
+		# signature == signature_with_slash_encoded != signature_with_slash_dont_encoded
+		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
+		self.assertEqual(signature, signature_with_slash_encoded)
+		self.assertNotEqual(signature, signature_with_slash_dont_encoded)
 
 	# method get
 	def test_request_to_api_get(self):

--- a/library/tests/test_niftycloud.py
+++ b/library/tests/test_niftycloud.py
@@ -113,6 +113,9 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 		signature = niftycloud.calculate_signature(secret_access_key, method, endpoint, path, params)
+
+		# This constant string is signature calculated by "library/tests/files/calculate_signature_sample.sh".
+		# This shell-script calculate with encoding a slash, like "niftycloud.calculate_signature()".
 		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
 
 	# method get

--- a/library/tests/test_niftycloud_fw.py
+++ b/library/tests/test_niftycloud_fw.py
@@ -222,6 +222,9 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 		signature = niftycloud_fw.calculate_signature(secret_access_key, method, endpoint, path, params)
+
+		# This constant string is signature calculated by "library/tests/files/calculate_signature_sample.sh".
+		# This shell-script calculate with encoding a slash, like "niftycloud.calculate_signature()".
 		self.assertEqual(signature, 'SsYPHOdKWpiniT39oGNJ5EjJum2gvqlUbozNxM9CSjE=')
 
 	# method get

--- a/library/tests/test_niftycloud_fw.py
+++ b/library/tests/test_niftycloud_fw.py
@@ -206,6 +206,24 @@ class TestNiftycloud(unittest.TestCase):
 		signature = niftycloud_fw.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, '+05Mgbw/WCN+U6euoFzHIyFi8i9UUTGg1uiNHqYcu38=')
 
+	# calculate signature with string parameter including slash
+	def test_calculate_signature_with_slash(self):
+		secret_access_key = self.mockModule.params['secret_access_key']
+		method = 'GET'
+		endpoint = self.mockModule.params['endpoint']
+		path = '/api/'
+		params = dict(
+			Action           = 'DescribeSecurityGroups',
+			AccessKeyId      = self.mockModule.params['access_key'],
+			SignatureMethod  = 'HmacSHA256',
+			SignatureVersion = '2',
+			GroupName        = self.mockModule.params['group_name'],
+			GroupDescription = '/'
+		)
+
+		signature = niftycloud_fw.calculate_signature(secret_access_key, method, endpoint, path, params)
+		self.assertEqual(signature, 'SsYPHOdKWpiniT39oGNJ5EjJum2gvqlUbozNxM9CSjE=')
+
 	# method get
 	def test_request_to_api_get(self):
 		method = 'GET'

--- a/library/tests/test_niftycloud_lb.py
+++ b/library/tests/test_niftycloud_lb.py
@@ -97,56 +97,8 @@ class TestNiftycloud(unittest.TestCase):
 			Description = '/'
 		)
 
-		# calculate a signature with slash URL-encoded
-		calculate_signature_with_slash_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
-			base64.b64encode(
-				hmac.new(
-					_secret_access_key,
-					'\n'.join([
-						_method,
-						_endpoint,
-						_path,
-						'&'.join([
-							'='.join([
-								_v[0],
-								urllib.quote(str(_v[1]), '')
-							]) for _v in sorted(_params.items())
-						])
-					]),
-					hashlib.sha256
-				).digest()
-			)
-		)
-
-		# calculate a signature with slash don't URL-encoded
-		calculate_signature_with_slash_dont_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
-			base64.b64encode(
-				hmac.new(
-					_secret_access_key,
-					'\n'.join([
-						_method,
-						_endpoint,
-						_path,
-						'&'.join([
-							'='.join([
-								_v[0],
-								urllib.quote(str(_v[1])) # '/' is default value of the 2nd argument
-							]) for _v in sorted(_params.items())
-						])
-					]),
-					hashlib.sha256
-				).digest()
-			)
-		)
-
-		signature                         = niftycloud_lb.calculate_signature(secret_access_key, method, endpoint, path, params)
-		signature_with_slash_encoded      = calculate_signature_with_slash_encoded(secret_access_key, method, endpoint, path, params)
-		signature_with_slash_dont_encoded = calculate_signature_with_slash_dont_encoded(secret_access_key, method, endpoint, path, params)
-
-		# signature == signature_with_slash_encoded != signature_with_slash_dont_encoded
+		signature = niftycloud_lb.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
-		self.assertEqual(signature, signature_with_slash_encoded)
-		self.assertNotEqual(signature, signature_with_slash_dont_encoded)
 
 	# method get
 	def test_request_to_api_get(self):

--- a/library/tests/test_niftycloud_lb.py
+++ b/library/tests/test_niftycloud_lb.py
@@ -98,6 +98,9 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 		signature = niftycloud_lb.calculate_signature(secret_access_key, method, endpoint, path, params)
+
+		# This constant string is signature calculated by "library/tests/files/calculate_signature_sample.sh".
+		# This shell-script calculate with encoding a slash, like "niftycloud.calculate_signature()".
 		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
 
 	# method get

--- a/library/tests/test_niftycloud_lb.py
+++ b/library/tests/test_niftycloud_lb.py
@@ -7,6 +7,7 @@ import unittest
 import mock
 import niftycloud_lb
 import xml.etree.ElementTree as etree
+import urllib, hmac, hashlib, base64
 
 class TestNiftycloud(unittest.TestCase):
 	def setUp(self):
@@ -80,6 +81,72 @@ class TestNiftycloud(unittest.TestCase):
 
 		signature = niftycloud_lb.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, 'Y7/0nc3dCK9UNkp+w5sh08ybJLQjh69mXOgcxJijDEU=')
+
+	# calculate signature with string parameter including slash
+	def test_calculate_signature_with_slash(self):
+		secret_access_key = self.mockModule.params['secret_access_key']
+		method = 'GET'
+		endpoint = self.mockModule.params['endpoint']
+		path = '/api/'
+		params = dict(
+			Action = 'DescribeInstances',
+			AccessKeyId = self.mockModule.params['access_key'],
+			SignatureMethod = 'HmacSHA256',
+			SignatureVersion = '2',
+			InstanceId = self.mockModule.params['instance_id'],
+			Description = '/'
+		)
+
+		# calculate a signature with slash URL-encoded
+		calculate_signature_with_slash_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
+			base64.b64encode(
+				hmac.new(
+					_secret_access_key,
+					'\n'.join([
+						_method,
+						_endpoint,
+						_path,
+						'&'.join([
+							'='.join([
+								_v[0],
+								urllib.quote(str(_v[1]), '')
+							]) for _v in sorted(_params.items())
+						])
+					]),
+					hashlib.sha256
+				).digest()
+			)
+		)
+
+		# calculate a signature with slash don't URL-encoded
+		calculate_signature_with_slash_dont_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
+			base64.b64encode(
+				hmac.new(
+					_secret_access_key,
+					'\n'.join([
+						_method,
+						_endpoint,
+						_path,
+						'&'.join([
+							'='.join([
+								_v[0],
+								urllib.quote(str(_v[1])) # '/' is default value of the 2nd argument
+							]) for _v in sorted(_params.items())
+						])
+					]),
+					hashlib.sha256
+				).digest()
+			)
+		)
+
+		signature                         = niftycloud_lb.calculate_signature(secret_access_key, method, endpoint, path, params)
+		signature_with_slash_encoded      = calculate_signature_with_slash_encoded(secret_access_key, method, endpoint, path, params)
+		signature_with_slash_dont_encoded = calculate_signature_with_slash_dont_encoded(secret_access_key, method, endpoint, path, params)
+
+		# signature == signature_with_slash_encoded != signature_with_slash_dont_encoded
+		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
+		self.assertEqual(signature, signature_with_slash_encoded)
+		self.assertNotEqual(signature, signature_with_slash_dont_encoded)
 
 	# method get
 	def test_request_to_api_get(self):

--- a/library/tests/test_niftycloud_volume.py
+++ b/library/tests/test_niftycloud_volume.py
@@ -91,56 +91,8 @@ class TestNiftycloud(unittest.TestCase):
 			Description = '/'
 		)
 
-		# calculate a signature with slash URL-encoded
-		calculate_signature_with_slash_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
-			base64.b64encode(
-				hmac.new(
-					_secret_access_key,
-					'\n'.join([
-						_method,
-						_endpoint,
-						_path,
-						'&'.join([
-							'='.join([
-								_v[0],
-								urllib.quote(str(_v[1]), '')
-							]) for _v in sorted(_params.items())
-						])
-					]),
-					hashlib.sha256
-				).digest()
-			)
-		)
-
-		# calculate a signature with slash don't URL-encoded
-		calculate_signature_with_slash_dont_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
-			base64.b64encode(
-				hmac.new(
-					_secret_access_key,
-					'\n'.join([
-						_method,
-						_endpoint,
-						_path,
-						'&'.join([
-							'='.join([
-								_v[0],
-								urllib.quote(str(_v[1])) # '/' is default value of the 2nd argument
-							]) for _v in sorted(_params.items())
-						])
-					]),
-					hashlib.sha256
-				).digest()
-			)
-		)
-
-		signature                         = niftycloud_volume.calculate_signature(secret_access_key, method, endpoint, path, params)
-		signature_with_slash_encoded      = calculate_signature_with_slash_encoded(secret_access_key, method, endpoint, path, params)
-		signature_with_slash_dont_encoded = calculate_signature_with_slash_dont_encoded(secret_access_key, method, endpoint, path, params)
-
-		# signature == signature_with_slash_encoded != signature_with_slash_dont_encoded
+		signature = niftycloud_volume.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
-		self.assertEqual(signature, signature_with_slash_encoded)
-		self.assertNotEqual(signature, signature_with_slash_dont_encoded)
 
 	# method get
 	def test_request_to_api_get(self):

--- a/library/tests/test_niftycloud_volume.py
+++ b/library/tests/test_niftycloud_volume.py
@@ -92,6 +92,9 @@ class TestNiftycloud(unittest.TestCase):
 		)
 
 		signature = niftycloud_volume.calculate_signature(secret_access_key, method, endpoint, path, params)
+
+		# This constant string is signature calculated by "library/tests/files/calculate_signature_sample.sh".
+		# This shell-script calculate with encoding a slash, like "niftycloud.calculate_signature()".
 		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
 
 	# method get

--- a/library/tests/test_niftycloud_volume.py
+++ b/library/tests/test_niftycloud_volume.py
@@ -7,6 +7,7 @@ import unittest
 import mock
 import niftycloud_volume
 import xml.etree.ElementTree as etree
+import urllib, hmac, hashlib, base64
 
 class TestNiftycloud(unittest.TestCase):
 	def setUp(self):
@@ -74,6 +75,72 @@ class TestNiftycloud(unittest.TestCase):
 
 		signature = niftycloud_volume.calculate_signature(secret_access_key, method, endpoint, path, params)
 		self.assertEqual(signature, 'Y7/0nc3dCK9UNkp+w5sh08ybJLQjh69mXOgcxJijDEU=')
+
+	# calculate signature with string parameter including slash
+	def test_calculate_signature_with_slash(self):
+		secret_access_key = self.mockModule.params['secret_access_key']
+		method = 'GET'
+		endpoint = self.mockModule.params['endpoint']
+		path = '/api/'
+		params = dict(
+			Action = 'DescribeInstances',
+			AccessKeyId = self.mockModule.params['access_key'],
+			SignatureMethod = 'HmacSHA256',
+			SignatureVersion = '2',
+			InstanceId = self.mockModule.params['instance_id'],
+			Description = '/'
+		)
+
+		# calculate a signature with slash URL-encoded
+		calculate_signature_with_slash_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
+			base64.b64encode(
+				hmac.new(
+					_secret_access_key,
+					'\n'.join([
+						_method,
+						_endpoint,
+						_path,
+						'&'.join([
+							'='.join([
+								_v[0],
+								urllib.quote(str(_v[1]), '')
+							]) for _v in sorted(_params.items())
+						])
+					]),
+					hashlib.sha256
+				).digest()
+			)
+		)
+
+		# calculate a signature with slash don't URL-encoded
+		calculate_signature_with_slash_dont_encoded = (lambda _secret_access_key, _method, _endpoint, _path, _params:
+			base64.b64encode(
+				hmac.new(
+					_secret_access_key,
+					'\n'.join([
+						_method,
+						_endpoint,
+						_path,
+						'&'.join([
+							'='.join([
+								_v[0],
+								urllib.quote(str(_v[1])) # '/' is default value of the 2nd argument
+							]) for _v in sorted(_params.items())
+						])
+					]),
+					hashlib.sha256
+				).digest()
+			)
+		)
+
+		signature                         = niftycloud_volume.calculate_signature(secret_access_key, method, endpoint, path, params)
+		signature_with_slash_encoded      = calculate_signature_with_slash_encoded(secret_access_key, method, endpoint, path, params)
+		signature_with_slash_dont_encoded = calculate_signature_with_slash_dont_encoded(secret_access_key, method, endpoint, path, params)
+
+		# signature == signature_with_slash_encoded != signature_with_slash_dont_encoded
+		self.assertEqual(signature, 'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4=')
+		self.assertEqual(signature, signature_with_slash_encoded)
+		self.assertNotEqual(signature, signature_with_slash_dont_encoded)
 
 	# method get
 	def test_request_to_api_get(self):


### PR DESCRIPTION
If the parameter contains a slash, signature and request parameters don't match.
Because `urllib.urlencode(dict)` used to generate the request parameter converts the slash, but `urllib.quote (str)` used to generate the signature does not convert slashes.

However, since the parameter 'description' does not exist at present, this problem does not occur.

### coverage result.

```
Name                   Stmts   Miss  Cover
------------------------------------------
niftycloud.py            171     31    82%
niftycloud_lb.py         125     21    83%
niftycloud_volume.py     105     25    76%
------------------------------------------
TOTAL                    401     77    81%
```