### PR TITLE
Change how to import ansible.module_utils.basic according to the official document

### DIFF
--- a/library/niftycloud.py
+++ b/library/niftycloud.py
@@ -23,7 +23,7 @@ import urllib
 import xml.etree.ElementTree as etree
 
 import requests
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *  # noqa
 
 
 DOCUMENTATION = '''
@@ -411,7 +411,7 @@ def restart_instance(module, current_state):
 
 
 def main():
-    module = AnsibleModule(
+    module = AnsibleModule(  # noqa
         argument_spec=dict(
             access_key=dict(required=True, type='str'),
             secret_access_key=dict(required=True, type='str', no_log=True),

--- a/library/niftycloud_fw.py
+++ b/library/niftycloud_fw.py
@@ -19,17 +19,18 @@ import base64
 import copy
 import hashlib
 import hmac
+import sys
 import time
 import urllib
 import xml.etree.ElementTree as etree
 
 import requests
-from ansible.module_utils.basic import AnsibleModule, sys
+from ansible.module_utils.basic import *  # noqa
 from ansible.module_utils.six import text_type
 
 try:
     # Python 2
-    unicode
+    unicode  # noqa
 except NameError:
     # Python 3
     unicode = text_type
@@ -673,7 +674,7 @@ def run(module):
 
 
 def main():
-    module = AnsibleModule(
+    module = AnsibleModule(  # noqa
         argument_spec=dict(
             access_key=dict(required=True,  type='str'),
             secret_access_key=dict(required=True,  type='str',  no_log=True),

--- a/library/niftycloud_lb.py
+++ b/library/niftycloud_lb.py
@@ -22,7 +22,7 @@ import urllib
 import xml.etree.ElementTree as etree
 
 import requests
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *  # noqa
 
 
 DOCUMENTATION = '''
@@ -299,7 +299,7 @@ def deregist_instance(module):
 
 
 def main():
-    module = AnsibleModule(
+    module = AnsibleModule(  # noqa
         argument_spec=dict(
             access_key=dict(required=True,  type='str'),
             secret_access_key=dict(required=True,  type='str', no_log=True),

--- a/library/niftycloud_volume.py
+++ b/library/niftycloud_volume.py
@@ -23,7 +23,7 @@ import urllib
 import xml.etree.ElementTree as etree
 
 import requests
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import *  # noqa
 
 
 DOCUMENTATION = '''
@@ -275,7 +275,7 @@ def detach_volume(module):
 
 
 def main():
-    module = AnsibleModule(
+    module = AnsibleModule(  # noqa
         argument_spec=dict(
             access_key=dict(required=True,  type='str'),
             secret_access_key=dict(required=True,  type='str', no_log=True),


### PR DESCRIPTION
##### SUMMARY
- change how to import ansible.modulw_utils.basic according to the [official document](http://docs.ansible.com/ansible/latest/dev_guide/developing_modules.html#appendix-module-utilities). 